### PR TITLE
JS fixes

### DIFF
--- a/src/com/hurlant/crypto/prng/SecureRandom.hx
+++ b/src/com/hurlant/crypto/prng/SecureRandom.hx
@@ -18,8 +18,8 @@ class SecureRandom {
             #if flash
                 return Bytes.ofData(untyped __global__["flash.crypto.generateRandomBytes"](length));
             #elseif js
-                untyped __js__('var crypto = crypto || require("crypto")');
-                var bytes:Dynamic = untyped __js__("(crypto.randomBytes) ? crypto.randomBytes({0}) : crypto.getRandomValues(new Int8Array({0}))", length);
+                untyped __js__('var Crypto = typeof crypto === "undefined" ? require("crypto") : crypto');
+                var bytes:Dynamic = untyped __js__("(Crypto.randomBytes) ? Crypto.randomBytes({0}) : Crypto.getRandomValues(new Uint8Array({0}))", length);
                 var out = Bytes.alloc(length);
                 for (n in 0 ... length) out.set(n, bytes[n]);
                 return out;


### PR DESCRIPTION
1. Changed the local variable crypto to Crypto; because Haxe emits JS in strict mode, as written this had been setting crypto to undefined before trying to use it.

2. Not a "fix" per se since haxe.io.Bytes internally converts ints to uints anyway, but it seems more idiomatic to use a Uint8Array rather than an Int8Array here.