### PR TITLE
Use implicit cast to avoid compile time error on flash target

### DIFF
--- a/src/com/hurlant/math/BigInteger.hx
+++ b/src/com/hurlant/math/BigInteger.hx
@@ -662,7 +662,7 @@ class BigInteger {
     public function exp(e:UInt, z:IReduction):BigInteger {
         //trace('aaaaaaaaaaaaa:$e');
 	#if flash
-        if (e > cast 0xffffffff || e < 1) return ONE; // use implicit cast to avoid compile time error on flash target
+	if (cast( e, Int ) > 0xffffffff || e < 1) return ONE; // use cast to avoid compile time error on flash target
 	#else	
         if (e > 0xffffffff || e < 1) return ONE;
 	#end

--- a/src/com/hurlant/math/BigInteger.hx
+++ b/src/com/hurlant/math/BigInteger.hx
@@ -661,7 +661,11 @@ class BigInteger {
 
     public function exp(e:UInt, z:IReduction):BigInteger {
         //trace('aaaaaaaaaaaaa:$e');
+	#if flash
         if (e > cast 0xffffffff || e < 1) return ONE; // use implicit cast to avoid compile time error on flash target
+	#else	
+        if (e > 0xffffffff || e < 1) return ONE;
+	#end
         var r = nbi();
         var r2 = nbi();
         var g = z.convert(this);

--- a/src/com/hurlant/math/BigInteger.hx
+++ b/src/com/hurlant/math/BigInteger.hx
@@ -661,7 +661,7 @@ class BigInteger {
 
     public function exp(e:UInt, z:IReduction):BigInteger {
         //trace('aaaaaaaaaaaaa:$e');
-        if (e > 0xffffffff || e < 1) return ONE;
+        if (e > cast 0xffffffff || e < 1) return ONE; // use implicit cast to avoid compile time error on flash target
         var r = nbi();
         var r2 = nbi();
         var g = z.convert(this);


### PR DESCRIPTION
I use this little library with the flash target (Adobe AIR) but always get an compile time error:
/haxe-crypto/0,0,6/src/com/hurlant/math/BigInteger.hx:664: characters 12-26 : Comparison of Int and UInt might lead to unexpected results

I'm using the latest Haxe 3,3,0 nightly build and remember adding this cast also to version 0.0.5 (only locally). Since I updated to 0.0.6 I had to do it again.

I wonder if this applies just to the flash target (don't think so) and hope this implicit cast will find it's way in the next version. (I hope it doesn't break anything - which an implicit cast doesn't)?