### PR TITLE
FIX: add -lib hx3compat to test builds so haxe.unit resolves under Haxe 4

### DIFF
--- a/tests.hxml
+++ b/tests.hxml
@@ -1,6 +1,7 @@
 -debug
 -cp src
 -cp test
+-lib hx3compat
 -main com.hurlant.tests.HaxeCryptoTests
 
 -js tests.js

--- a/tests_all.hxml
+++ b/tests_all.hxml
@@ -1,6 +1,7 @@
 -debug
 -cp src
 -cp test
+-lib hx3compat
 -main com.hurlant.tests.HaxeCryptoTests
 
 --each

--- a/tests_native.hxml
+++ b/tests_native.hxml
@@ -1,6 +1,7 @@
 -debug
 -cp src
 -cp test
+-lib hx3compat
 -main com.hurlant.tests.HaxeCryptoTests
 
 --each


### PR DESCRIPTION
## Summary

- Adds `-lib hx3compat` to `tests.hxml`, `tests_all.hxml`, and `tests_native.hxml` so `haxe.unit` is available under Haxe 4

## Test plan

- [x] `haxe tests.hxml` compiles and all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)