### PR TITLE
CHORE: ignore Claude Code runtime artifacts in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ docs/validation_errors.log
 /tests.n*
 /tests.swf*
 client.swf
+
+.claude/cache/
+.claude/logs/
+.claude/memory.md
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

- Adds `.claude/cache/`, `.claude/logs/`, `.claude/memory.md`, and `.claude/settings.local.json` to `.gitignore` so Claude Code runtime files are not accidentally staged
- Also fixes missing newline at end of file

## Test plan

- [x] Verified the new entries match the actual paths generated by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)